### PR TITLE
Include systemd support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Makefile.in
 
 /rpmbuild
 /sources
+.project

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 name=argus-pap
-tag=1_6
+tag=fix/ISSUE-6
 
 # the Github repo 
 git=git://github.com/argus-authz/argus-pap.git

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 name=argus-pap
-tag=fix/ISSUE-6
+tag=1_6
 
 # the Github repo 
 git=git://github.com/argus-authz/argus-pap.git

--- a/argus-pap.spec.in
+++ b/argus-pap.spec.in
@@ -130,6 +130,8 @@ fi
 
 %if 0%{?rhel} >= 7 || 0%{?fedora} >= 21
 /lib/systemd/system/argus-pap.service
+%else
+%exclude /lib/systemd/system/argus-pap.service
 %endif
 
 %changelog

--- a/argus-pap.spec.in
+++ b/argus-pap.spec.in
@@ -128,7 +128,14 @@ fi
 
 %dir %{_localstatedir}/log/argus/pap
 
+%if 0%{?rhl} >= 7 || 0%{?fedora} >= 21
+/lib/systemd/system/argus-pap.service
+%endif
+
 %changelog
+* Tue Nov 17 2015 Marco Caberletti <marco.caberletti at cnaf.infn.it> - 1.6.3-1
+- Support to Systemd
+
 * Thu Jul 2 2015 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 1.6.3-0
 - Move to java 8
 
@@ -138,7 +145,7 @@ fi
 * Thu Apr 11 2013 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 1.6.1-1
 - Fix for https://savannah.cern.ch/bugs/?101151
 
-* Wed Oct 16 2012 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 1.6.0-1
+* Tue Oct 16 2012 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 1.6.0-1
 - CANL-based Argus PAP.
 - Decouple PAP pom version from rpm version.
 

--- a/argus-pap.spec.in
+++ b/argus-pap.spec.in
@@ -128,7 +128,7 @@ fi
 
 %dir %{_localstatedir}/log/argus/pap
 
-%if 0%{?rhl} >= 7 || 0%{?fedora} >= 21
+%if 0%{?rhel} >= 7 || 0%{?fedora} >= 21
 /lib/systemd/system/argus-pap.service
 %endif
 


### PR DESCRIPTION
Add unit file to manage Argus services with systemd in EL7 and Fedora.
